### PR TITLE
Links to github repository changed to IATI

### DIFF
--- a/index.php
+++ b/index.php
@@ -393,8 +393,8 @@ function build_sanitised_multi_select_values ($path_to_csv,$sanitized_post_var) 
                 <div class="ss-legal">
                   <div class="disclaimer-separator">
                     <p>IATI Query Builder is Free Software licenced under the GNU General Public License<br/>
-                    <a href="https://github.com/caprenter/IATI-Query-Builder">IATI Query Builder on GitHub</a> <br/>
-                    Please report problems to our <a href="https://github.com/caprenter/IATI-Query-Builder/issues">issues list</a>.</br>
+                    <a href="https://github.com/IATI/IATI-Query-Builder">IATI Query Builder on GitHub</a> <br/>
+                    Please report problems to our <a href="https://github.com/IATI/IATI-Query-Builder/issues">issues list</a>.</br>
                     Datastore documentation: <a href="http://datastore.iatistandard.org/">http://datastore.iatistandard.org</a>
                     </p>
                     </div>


### PR DESCRIPTION
Links are coded to pointed to old repository. GitHub will handle redirects, but this just fixes them.
