### PR TITLE
Use CURLOPT_ENCODING in place of `Accept-Encoding`

### DIFF
--- a/helpers/CKAN_Code/Ckan_client.php
+++ b/helpers/CKAN_Code/Ckan_client.php
@@ -154,6 +154,8 @@ class Ckan_client
 		curl_setopt($this->ch, CURLINFO_HEADER_OUT, TRUE);
 		// Attempt to retrieve the modification date of the remote document.
 		curl_setopt($this->ch, CURLOPT_FILETIME, TRUE);
+		// Accept gzipped content
+		curl_setopt($this->ch, CURLOPT_ENCODING, 'gzip');
 		// Initialize cURL headers
 		$this->set_headers();
 		// Include PHP Markdown library
@@ -217,8 +219,7 @@ class Ckan_client
 		$this->ch_headers = array(
 			'Date: ' . $date->format('D, d M Y H:i:s') . ' GMT', // RFC 1123
 			'Accept: application/json;q=1.0, application/xml;q=0.5, */*;q=0.0',
-			'Accept-Charset: utf-8',
-			'Accept-Encoding: gzip'
+			'Accept-Charset: utf-8'
 		);
 	}
 


### PR DESCRIPTION
Fixes #25.