### PR TITLE
Default radios to first value

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,6 @@
               {{ error_message }}
             </div>
             {% endif %}
-            <div class="ss-required-asterisk">*Required</div>
           </div>
         </div>
         <div class="ss-form">
@@ -39,14 +38,13 @@
                   <label class="ss-q-item-label" for="entry_1689841214">
                     <div class="ss-q-title">Choose Format
                       <label for="itemView.getDomIdToLabel()" aria-label="(Required field)"></label>
-                      <span class="ss-required-asterisk">*</span>
                     </div>
                   </label>
                   <ul class="ss-choices">
                     <li class="ss-choice-item">
                       <label>
                         <input type="radio" name="entry.1085079344" value="activity" id="group_1085079344_1" class="ss-q-radio" aria-label="Activity"
-                        {% if dataset and dataset == "activity" %}
+                        {% if not dataset or (dataset and dataset == "activity") %}
                           checked="checked"
                         {% endif %}
                         />
@@ -83,14 +81,13 @@
                   <label class="ss-q-item-label" for="entry_1948547450">
                     <div class="ss-q-title">Repeat Rows?
                       <label for="itemView.getDomIdToLabel()" aria-label="(Required field)"></label>
-                      <span class="ss-required-asterisk">*</span>
                     </div>
                   </label>
                   <ul class="ss-choices">
                     <li class="ss-choice-item">
                       <label>
                         <input type="radio" name="entry.71167035" value="summary" id="group_71167035_1" class="ss-q-radio" aria-label="Summary"
-                        {% if format and format == "summary" %}
+                        {% if not format or (format and format == "summary") %}
                           checked="checked"
                         {% endif %}
                         />
@@ -127,14 +124,13 @@
                   <label class="ss-q-item-label" for="entry_1414120858">
                     <div class="ss-q-title">Choose Sample Size
                       <label for="itemView.getDomIdToLabel()" aria-label="(Required field)"></label>
-                      <span class="ss-required-asterisk">*</span>
                     </div>
                   </label>
                   <ul class="ss-choices">
                     <li class="ss-choice-item">
                       <label>
                         <input type="radio" name="entry.1352830161" value="50 rows" id="group_1352830161_1" class="ss-q-radio" aria-label="50 rows"
-                        {% if size and size == "50 rows" %}
+                        {% if not size or (size and size == "50 rows") %}
                           checked="checked"
                         {% endif %}
                         />


### PR DESCRIPTION
Fixes #36. This also drops the “required” stuff, since that isn’t really needed once the radios have default values.