### PR TITLE
Complete the js-with-php-fallback idea

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -18,22 +18,17 @@
 
       <div class="query-builder">
         <div class="row"><!-- result -->
-          <div class="alert alert-success" id="js-query-link" role="alert">
-            <strong>Your link:</strong> <a href="http://datastore.iatistandard.org/api/1/access/activity.csv">http://datastore.iatistandard.org/api/1/access/activity.csv</a>
+          <div class="alert alert-success {% if not api_link %}d-none{% endif %}" id="js-query-link" role="alert">
+            <strong>Your link:</strong> <a href="{{ api_link }}">{{ api_link|escape }}</a>
           </div>
 
-          {% if api_link %}
-            <div class="alert alert-success" role="alert">
-              <strong>Your link:</strong> <a href="{{ api_link }}">{{ api_link|escape }}</a>
+          {% if notice_message %}
+            <div class="alert alert-warning" role="alert">
+              <strong>Warning:</strong> {{ notice_message }}
             </div>
+          {% endif %}
 
-            {% if notice_message %}
-              <div class="alert alert-warning" role="alert">
-                <strong>Warning:</strong> {{ notice_message }}
-              </div>
-            {% endif %}
-
-          {% elseif error_message %}
+          {% if error_message %}
             <div class="alert alert-danger" role="alert">
               <strong>Error:</strong> {{ error_message }}
             </div>
@@ -356,12 +351,16 @@ QueryBuilder.LinkGen.createLink = function(){
   Update the link displayed on the page.
 */
 QueryBuilder.LinkGen.updateLink = function(){
-  var linkElement = $('#js-query-link a');
+  var alertElement = $('#js-query-link');
+  var linkElement = alertElement.find('a');
   var linkLocation = QueryBuilder.LinkGen.createLink();
 
   // update the link
   linkElement.attr('href', linkLocation);
   linkElement.text(linkLocation);
+
+  // ensure the alert is visible
+  alertElement.removeClass('d-none');
 };
 
 /*

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,10 @@
 
       <div class="query-builder">
         <div class="row"><!-- result -->
+          <div class="alert alert-success" id="js-query-link" role="alert">
+            <p><strong>Your link:</strong> <a href="http://datastore.iatistandard.org/api/1/access/activity.csv">http://datastore.iatistandard.org/api/1/access/activity.csv</a></p>
+          </div>
+
           {% if api_link %}
             <div class="alert alert-success" role="alert">
               <strong>Your link:</strong> <a href="{{ api_link }}">{{ api_link|escape }}</a>
@@ -221,10 +225,6 @@
           </div>
 
         </form>
-
-        <div class="alert alert-success" id="js-query-link" role="alert">
-          <p><strong>Your link:</strong> <a href="http://datastore.iatistandard.org/api/1/access/activity.csv">http://datastore.iatistandard.org/api/1/access/activity.csv</a></p>
-        </div>
 
       </div><!-- end class="query-builder"-->
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
       <div class="query-builder">
         <div class="row"><!-- result -->
           <div class="alert alert-success" id="js-query-link" role="alert">
-            <p><strong>Your link:</strong> <a href="http://datastore.iatistandard.org/api/1/access/activity.csv">http://datastore.iatistandard.org/api/1/access/activity.csv</a></p>
+            <strong>Your link:</strong> <a href="http://datastore.iatistandard.org/api/1/access/activity.csv">http://datastore.iatistandard.org/api/1/access/activity.csv</a>
           </div>
 
           {% if api_link %}


### PR DESCRIPTION
#55 did almost all of the work to make the query builder work in javascript with a PHP fallback (hooray!) This PR adds some finishing touches, to make it all look nice and neat.

 * Remove the javascript alert at the bottom of the page
 * Instead, use the same alert for PHP and javascript
 * Hide the alert by default, unless we have an `api_link` from the server
 * Unhide the alert with javascript (and update it onchange as before)

I suppose for this to be totally 100% done, the notice message alert and error message alert should also be triggered and populated in javascript. But I’m not going to do that because I’m hoping they’ll both become redundant before long.