### PR TITLE
Bugfix: size should be set regardless of other params

### DIFF
--- a/index.php
+++ b/index.php
@@ -111,7 +111,7 @@ if (isset($_POST) && $_POST != NULL) {
     $api_link .= ".csv";
    //echo $api_link;
    //print_r($orgs);
-    if ( isset($orgs) || isset($type) || isset($sector) || isset($country) || isset($region) ) {
+    if ( isset($orgs) || isset($type) || isset($sector) || isset($country) || isset($region) || isset($size)) {
       $api_link .= "?";
       $api_link_parameters = array();
       if (isset($orgs)) {


### PR DESCRIPTION
Steps to recreate:
 1. Go to http://datastore.iatistandard.org/query/
 2. Select “Entire selection”
 3. Submit

Expected URL: http://datastore.iatistandard.org/api/1/access/activity.csv?stream=True
Actual URL: http://datastore.iatistandard.org/api/1/access/activity.csv