### PR TITLE
Replace “generate link to CSV” button with “download CSV” button

### DIFF
--- a/index.php
+++ b/index.php
@@ -134,6 +134,8 @@ if (isset($_POST) && $_POST != NULL) {
       }
       $api_link .= http_build_query($api_link_parameters);
     }
+    header("Location:" . $api_link);
+    return;
   } else {
     $error_message = "You must select something from each of the 3 required fields";
   }

--- a/templates/index.html
+++ b/templates/index.html
@@ -222,10 +222,6 @@
 
         </form>
 
-        <div class="alert alert-success" id="js-query-link" role="alert">
-          <p><strong>Your link:</strong> <a href="http://datastore.iatistandard.org/api/1/access/activity.csv">http://datastore.iatistandard.org/api/1/access/activity.csv</a></p>
-        </div>
-
       </div><!-- end class="query-builder"-->
 
 
@@ -359,7 +355,6 @@ QueryBuilder.LinkGen.updateLink = function(){
 
   // update the link
   linkElement.attr('href', linkLocation);
-  linkElement.text(linkLocation);
 };
 
 /*
@@ -375,6 +370,7 @@ QueryBuilder.LinkGen.SetupEventListeners = function(){
   Initialise the client-side link generation.
 */
 QueryBuilder.LinkGen.Init = function(){
+  $('#js-query-link').prepend('<a class="btn btn-primary">Download</a>');
   QueryBuilder.LinkGen.SetupEventListeners();
   QueryBuilder.LinkGen.updateLink();
 };

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,18 +18,13 @@
 
       <div class="query-builder">
         <div class="row"><!-- result -->
-          {% if api_link %}
-            <div class="alert alert-success" role="alert">
-              <strong>Your link:</strong> <a href="{{ api_link }}">{{ api_link|escape }}</a>
+          {% if notice_message %}
+            <div class="alert alert-warning" role="alert">
+              <strong>Warning:</strong> {{ notice_message }}
             </div>
+          {% endif %}
 
-            {% if notice_message %}
-              <div class="alert alert-warning" role="alert">
-                <strong>Warning:</strong> {{ notice_message }}
-              </div>
-            {% endif %}
-
-          {% elseif error_message %}
+          {% if error_message %}
             <div class="alert alert-danger" role="alert">
               <strong>Error:</strong> {{ error_message }}
             </div>
@@ -214,8 +209,8 @@
           </div>
 
           <div class="form-row">
-            <div class="col">
-              <noscript><button class="btn btn-primary" type="submit">Submit</button></noscript>
+            <div class="col" id="js-query-link">
+              <noscript><button class="btn btn-primary" type="submit">Download</button></noscript>
               <button class="btn btn-secondary" type="reset">Reset</button>
             </div>
           </div>


### PR DESCRIPTION
![download gif](https://user-images.githubusercontent.com/464193/30781339-53dbf342-a115-11e7-8336-c1051c0f53fb.gif)

I suspect that most users don’t care about the generated link – I think it’s just an extra interim step to getting the CSV. This PR cuts out that step, and turns the “submit the form” + “here’s your link” steps into a single “download the CSV” step.