### PR TITLE
Remove wrapping <p> inside alert div

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -223,7 +223,7 @@
         </form>
 
         <div class="alert alert-success" id="js-query-link" role="alert">
-          <p><strong>Your link:</strong> <a id="query-link" href="http://datastore.iatistandard.org/api/1/access/activity.csv">http://datastore.iatistandard.org/api/1/access/activity.csv</a> <span id="preview-link-wrapper">(<a id="preview-link" href="http://preview.iatistandard.org/" target="_blank" rel="noopener noreferrer">Preview as XML</a>)</span></p>
+          <strong>Your link:</strong> <a id="query-link" href="http://datastore.iatistandard.org/api/1/access/activity.csv">http://datastore.iatistandard.org/api/1/access/activity.csv</a> <span id="preview-link-wrapper">(<a id="preview-link" href="http://preview.iatistandard.org/" target="_blank" rel="noopener noreferrer">Preview as XML</a>)</span>
         </div>
 
       </div><!-- end class="query-builder"-->


### PR DESCRIPTION
Bootstrap alerts don’t need to contain a `<p>`. See the docs:
https://getbootstrap.com/docs/4.0/components/alerts/

The bottom margin on the `<p>` adds a load of padding that looks really ugly.
![screen shot 2017-09-26 at 12 50 27](https://user-images.githubusercontent.com/464193/30858867-5562ab70-a2b9-11e7-9632-c575cbe1ae4a.png)

I fixed the other instances of this in 5b879198, but this one was added since.