### PR TITLE
Swap before and after dates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -179,20 +179,20 @@
                 <div class="clearfix"></div>
                 <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd">
                   <div class="input-group-addon">
-                    <span class="tooltip-ui" data-toggle="tooltip" title="Identify activities with start dates before the specified date.">
-                      Before
-                    </span>
-                  </div>
-                  <input class="form-control" placeholder="yyyy-mm-dd" type="text" id="start_date__lt" name="start_date__lt" value="{{ start_date__lt }}">
-                  </input>
-                </div>
-                <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd">
-                  <div class="input-group-addon">
                     <span class="tooltip-ui" data-toggle="tooltip" title="Identify activities with start dates after the specified date.">
                       After
                     </span>
                   </div>
                   <input class="form-control" placeholder="yyyy-mm-dd" type="text" id="start_date__gt" name="start_date__gt" value="{{ start_date__gt }}">
+                  </input>
+                </div>
+                <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd">
+                  <div class="input-group-addon">
+                    <span class="tooltip-ui" data-toggle="tooltip" title="Identify activities with start dates before the specified date.">
+                      Before
+                    </span>
+                  </div>
+                  <input class="form-control" placeholder="yyyy-mm-dd" type="text" id="start_date__lt" name="start_date__lt" value="{{ start_date__lt }}">
                   </input>
                 </div>
               </div>
@@ -206,21 +206,21 @@
                 </label for="end_date">
                 <div class="clearfix"></div>
                 <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd">
-                  <div class="input-group-addon">
-                    <span class="tooltip-ui" data-toggle="tooltip" title="Identify activities with end dates before the specified date.">
-                      Before
-                    </span>
-                  </div>
-                  <input class="form-control" placeholder="yyyy-mm-dd" type="text" id="end_date__lt" name="end_date__lt" value="{{ end_date__lt }}">
-                  </input>
-                </div>
-                <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd">
                   <div class="input-group-addon"/>
                     <span class="tooltip-ui" data-toggle="tooltip" title="Identify activities with end dates after the specified date.">
                       After
                     </span>
                   </div>
                   <input class="form-control" placeholder="yyyy-mm-dd" type="text" id="end_date__gt" name="end_date__gt" value="{{ end_date__gt }}">
+                  </input>
+                </div>
+                <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd">
+                  <div class="input-group-addon">
+                    <span class="tooltip-ui" data-toggle="tooltip" title="Identify activities with end dates before the specified date.">
+                      Before
+                    </span>
+                  </div>
+                  <input class="form-control" placeholder="yyyy-mm-dd" type="text" id="end_date__lt" name="end_date__lt" value="{{ end_date__lt }}">
                   </input>
                 </div>
               </div>


### PR DESCRIPTION
If you think of them defining a range for e.g. the start date, it’s more
natural to set the lower bound of that range first, and the upper bound
second.