### PR TITLE
Make reset behave correctly after a POST

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -401,7 +401,7 @@
 
             <div class="col submit-buttons">
               <noscript><button class="btn btn-primary" type="submit">Build Query</button></noscript>
-              <button class="btn btn-secondary" type="reset">Reset</button>
+              <button class="btn btn-secondary" type="submit" name="reset" value="Reset" id="reset">Reset</button>
             </div>
           </div>
 
@@ -673,6 +673,7 @@ $(function() {
     // initialise chosen
     $(".chosen-select").chosen();
 
+    $('#reset').attr('type', 'reset');
     $('#qb-form').on('reset', QueryBuilder.UI.resetSelection);
 
     // init tooltips


### PR DESCRIPTION
Refs #87.

No need to change anything in the PHP code, since [this legacy code](https://github.com/IATI/IATI-Query-Builder/blob/20de79d2b6df22aab34473b91bb7238124edfe10/index.php#L11-L13) is still there.

Sliiiightly concerned about [the note here](https://api.jquery.com/prop/) i.e.:

> **Note**: Attempting to change the `type` property (or attribute) of an `input` element created via HTML or already in an HTML document will result in an error being thrown by Internet Explorer 6, 7, or 8.

…but perhaps it’s fine for a `button`?