### PR TITLE
Add a download button

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -594,7 +594,7 @@ $(function() {
     var formElements = $('select, input[type=text], input[type=radio]');
 
     formElements.change(QueryBuilder.LinkGen.updateLink);
-    };
+  };
 
   /*
     Initialise the client-side link generation.

--- a/templates/index.html
+++ b/templates/index.html
@@ -577,11 +577,14 @@ $(function() {
   */
   QueryBuilder.LinkGen.updateLink = function(){
     var linkElement = $('#query-link');
+    var downloadButton = $('#download');
     var linkLocation = QueryBuilder.LinkGen.createLink();
 
     // update the link
     linkElement.attr('href', linkLocation);
     linkElement.text(linkLocation);
+
+    downloadButton.attr('href', linkLocation);
   };
 
   /*
@@ -598,6 +601,7 @@ $(function() {
   */
   QueryBuilder.LinkGen.Init = function(){
     $('#js-query-link').show();
+    $('.submit-buttons').prepend('<a id="download" class="btn btn-primary" href="#">Download</a>');
 
     QueryBuilder.LinkGen.SetupEventListeners();
     QueryBuilder.LinkGen.updateLink();


### PR DESCRIPTION
Fixes #96 (in the sense that the primary call to action – the button at the end of the form – now does the thing the user is probably trying to do.)

This adds a download button in javascript, that performs a direct download of the CSV file.

![yswcwy8gqf](https://user-images.githubusercontent.com/464193/32047661-976279dc-ba3e-11e7-84ef-16afb40e0768.gif)

This PR is similar to #72, but instead of replacing the link, it is in addition to the link.

(The next step after this would be to move the link into a form input with a copy function.)