### PR TITLE
Updating to use ckan 2.8 API

### DIFF
--- a/helpers/CKAN_Code/Ckan_client.php
+++ b/helpers/CKAN_Code/Ckan_client.php
@@ -34,7 +34,7 @@ class Ckan_client
 	 * @link	http://knowledgeforge.net/ckan/doc/ckan/api.html#api-versions
 	 * @since	Version 0.1.0
 	 */
-	private $api_version = '1';
+	private $api_version = '3';
 
 	/**
 	 * URI to the CKAN web service.
@@ -83,18 +83,18 @@ class Ckan_client
 	 * @since	Version 0.1.0
 	 */
 	private $resources = array(
-		'package_register' => 'rest/package',
-		'package_entity' => 'rest/package',
-		'group_register' => 'rest/group',
-		'group_entity' => 'rest/group',
-		'tag_register' => 'rest/tag',
-		'tag_entity' => 'rest/tag',
-		'rating_register' => 'rest/rating',
-		'rating_entity' => 'rest/rating',
-		'revision_register' => 'rest/revision',
-		'revision_entity' => 'rest/revision',
-		'license_list' => 'rest/licenses',
-		'package_search' => 'search/package'
+		'package_register' => 'action/package_list',
+		'package_entity' => 'action/package_show',
+		'group_register' => 'action/group_list',
+		'group_entity' => 'action/group_show',
+		'tag_register' => 'action/tag_list',
+		'tag_entity' => 'action/tag_show',
+		'rating_register' => 'action/rating_list',
+		'rating_entity' => 'action/rating_show',
+		'revision_register' => 'action/revision_list',
+		'revision_entity' => 'action/revision_show',
+		'license_list' => 'action/licenses_list',
+		'package_search' => 'action/package_search'
 	);
 
 	/**
@@ -284,7 +284,7 @@ class Ckan_client
 	public function get_package_entity($package)
 	{
 		return $this->make_request('GET', 
-			$this->resources['package_entity'] . '/' . urlencode($package));
+			$this->resources['package_entity'] . '?id=' . urlencode($package));
 	}
 
 	/**
@@ -298,7 +298,7 @@ class Ckan_client
 	public function put_package_entity($package, $data)
 	{
 		return $this->make_request('PUT', 
-			$this->resources['package_entity'] . '/' . urlencode($package), 
+			$this->resources['package_entity'] . '?id=' . urlencode($package), 
 			$data);
 	}
 
@@ -346,8 +346,9 @@ class Ckan_client
 	 */
 	public function get_group_entity($group)
 	{
+		print($group);
 		return $this->make_request('GET', 
-			$this->resources['group_entity'] . '/' . urlencode($group));
+			$this->resources['group_entity'] . '?id=' . urlencode($group));
 	}
 
 	// Group utility alias
@@ -391,7 +392,7 @@ class Ckan_client
 	public function get_tag_entity($tag)
 	{
 		return $this->make_request('GET', $this->resources['tag_entity'] . 
-			'/' . urlencode($tag));
+			'?id=' . urlencode($tag));
 	}
 
 	// Tag utility alias
@@ -433,7 +434,7 @@ class Ckan_client
 	public function get_revision_entity($revision)
 	{
 		return $this->make_request('GET', 
-			$this->resources['revision_entity'] . '/' . urlencode($revision));
+			$this->resources['revision_entity'] . '?id=' . urlencode($revision));
 	}
 
 	// Revision utility alias

--- a/helpers/functions.php
+++ b/helpers/functions.php
@@ -50,10 +50,10 @@ function reporting_orgs() {
   $reporting_orgs = array();
   $excluded_ids = array("To be confirmed.");
   foreach ($groups as $key=>$value) {
-    if (!empty($value["packages"])) { //only select publishers with files!
-      if (!empty($value["extras"]["publisher_iati_id"])) { //only select publishers with and id
-        if (!in_array($value["extras"]["publisher_iati_id"],$excluded_ids)) { //don't select publishers with excluded ids
-          $reporting_orgs[$value["display_name"]] = $value["extras"]["publisher_iati_id"];
+    if (($value["result"]["package_count"])> 0) { //only select publishers with files!
+      if (!empty($value["result"]["publisher_iati_id"])) { //only select publishers with and id
+        if (!in_array($value["result"]["publisher_iati_id"],$excluded_ids)) { //don't select publishers with excluded ids
+          $reporting_orgs[$value["result"]["title"]] = $value["result"]["publisher_iati_id"];
         }
       }
     }

--- a/index.php
+++ b/index.php
@@ -70,15 +70,14 @@ if (isset($_POST) && $_POST != NULL) {
   $cachefile = "helpers/groups_cache_dc.json";
   $groups = file_get_contents($cachefile);
   $groups = json_decode($groups,true);
-
   //Set up an array of Organisations and their IDs
   $reporting_orgs = array();
   $excluded_ids = array("To be confirmed.");
   foreach ($groups as $key=>$value) {
-    if (!empty($value["packages"])) { //only select publishers with files!
-      if (!empty($value["extras"]["publisher_iati_id"])) { //only select publishers with and id
-        if (!in_array($value["extras"]["publisher_iati_id"],$excluded_ids)) { //don't select publishers with excluded ids
-          $allowed_orgs[] = $value["extras"]["publisher_iati_id"];
+    if (($value["result"]["package_count"])> 0) { //only select publishers with files!
+      if (!empty($value["result"]["publisher_iati_id"])) { //only select publishers with and id
+        if (!in_array($value["result"]["publisher_iati_id"],$excluded_ids)) { //don't select publishers with excluded ids
+          $allowed_orgs[] = $value["result"]["publisher_iati_id"];
         }
       }
     }


### PR DESCRIPTION
Quick fix to make the query builder pull information from the updated version of the ckan API in the iatiregistry, might need some polishing but this should update the query builder's publisher list. 